### PR TITLE
chore: add ParserPlugin to copied babel/parser export

### DIFF
--- a/lib/babel-parser.ts
+++ b/lib/babel-parser.ts
@@ -2,6 +2,7 @@
 
 
 import { ParserOptions } from '@babel/parser';
+import type { ParserPlugin } from '@babel/parser';
 import { ClassBody, MemberExpression, Node, Program, } from '@babel/types';
 declare class Parser {
     input: string;
@@ -30,5 +31,6 @@ declare const mixinPlugins: Record<string, Function>;
 
 export {
     Parser,
-    mixinPlugins,
+    ParserPlugin,
+    mixinPlugins
 }

--- a/lib/transform-embedded-templates.ts
+++ b/lib/transform-embedded-templates.ts
@@ -24,7 +24,7 @@ import {
     templateLiteral,
     TemplateLiteral
 } from '@babel/types';
-import { ParserPlugin } from '@babel/parser';
+import type { ParserPlugin } from './babel-parser';
 import { NodePath, default as babelTraverse, visitors } from '@babel/traverse';
 import { default as generate } from '@babel/generator';
 import { getTemplateLocals } from '@glimmer/syntax';

--- a/scripts/copy-parser.js
+++ b/scripts/copy-parser.js
@@ -5,6 +5,6 @@ const parserPath = require.resolve('@babel/parser');
 let parserContent = fs.readFileSync(parserPath).toString().split('\n').slice(0, -5).join('\n');
 parserContent = '// @ts-nocheck\n' + parserContent;
 parserContent += '\n';
-parserContent += 'export { Parser, mixinPlugins }\n';
+parserContent += 'export { Parser, ParserPlugin, mixinPlugins }\n';
 
 fs.writeFileSync(path.join(__dirname, '..', 'lib/babel-parser.ts'), parserContent);


### PR DESCRIPTION
Additional fixes for #11 
Fixes the `@babel/parser` dependency by reexporting the `ParserPlugin` from the copied babel/parser.