### PR TITLE
chore: remove ParserPlugin type and just use any instead

### DIFF
--- a/lib/babel-parser.ts
+++ b/lib/babel-parser.ts
@@ -2,7 +2,6 @@
 
 
 import { ParserOptions } from '@babel/parser';
-import type { ParserPlugin } from '@babel/parser';
 import { ClassBody, MemberExpression, Node, Program, } from '@babel/types';
 declare class Parser {
     input: string;
@@ -31,6 +30,5 @@ declare const mixinPlugins: Record<string, Function>;
 
 export {
     Parser,
-    ParserPlugin,
     mixinPlugins
 }

--- a/lib/transform-embedded-templates.ts
+++ b/lib/transform-embedded-templates.ts
@@ -24,7 +24,6 @@ import {
     templateLiteral,
     TemplateLiteral
 } from '@babel/types';
-import type { ParserPlugin } from './babel-parser';
 import { NodePath, default as babelTraverse, visitors } from '@babel/traverse';
 import { default as generate } from '@babel/generator';
 import { getTemplateLocals } from '@glimmer/syntax';
@@ -202,7 +201,7 @@ type PreprocessOptions = {
     relativePath: string;
     explicitMode?: boolean;
     linterMode?: boolean;
-    babelPlugins?: ParserPlugin[];
+    babelPlugins?: any[];
     includeSourceMaps?: boolean | 'inline' | 'both';
     getTemplateLocals?: (html: string, options?: any) => string[]
 }
@@ -245,7 +244,7 @@ export function transform(options: PreprocessOptions) {
 
 export function doTransform(options: PreprocessOptions) {
 
-    const plugins = (['decorators', 'typescript', 'classProperties', 'classStaticBlock', 'classPrivateProperties'] as ParserPlugin[]).concat(options.babelPlugins || []);
+    const plugins = (['decorators', 'typescript', 'classProperties', 'classStaticBlock', 'classPrivateProperties'] as any[]).concat(options.babelPlugins || []);
     let ast = options.ast as any;
     if (!ast) {
         ast = parse(options.input, {

--- a/scripts/copy-parser.js
+++ b/scripts/copy-parser.js
@@ -5,6 +5,6 @@ const parserPath = require.resolve('@babel/parser');
 let parserContent = fs.readFileSync(parserPath).toString().split('\n').slice(0, -5).join('\n');
 parserContent = '// @ts-nocheck\n' + parserContent;
 parserContent += '\n';
-parserContent += 'export { Parser, ParserPlugin, mixinPlugins }\n';
+parserContent += 'export { Parser, mixinPlugins }\n';
 
 fs.writeFileSync(path.join(__dirname, '..', 'lib/babel-parser.ts'), parserContent);


### PR DESCRIPTION
I was able to test out the new release and apparently the copied parser doesn't export the type along with the code. I ended up just removing it and switching the one use to `any` to shut it up.

Sorry bout the churn!